### PR TITLE
6-9kyo-hwang

### DIFF
--- a/9-kyo-hwang/README.md
+++ b/9-kyo-hwang/README.md
@@ -7,4 +7,5 @@
 | 3차시 | 2023.11.12 | 최소 스패닝 트리 | [16398 행성 연결](https://www.acmicpc.net/problem/16398) | [#7](https://github.com/AlgoLeadMe/AlgoLeadMe-3/pull/7) | 
 | 4차시 | 2023.11.14 | 트라이 | [5052 전화번호 목록](https://www.acmicpc.net/problem/5052) | [#11](https://github.com/AlgoLeadMe/AlgoLeadMe-3/pull/11) | 
 | 5차시 | 2023.11.17 | 플로이드-워셜 | [1613 역사](https://www.acmicpc.net/problem/1613) | [#15](https://github.com/AlgoLeadMe/AlgoLeadMe-3/pull/15) | 
+| 6차시 | 2023.11.19 | 다익스트라 | [22865 가장 먼 곳](https://www.acmicpc.net/problem/122865) | [#19](https://github.com/AlgoLeadMe/AlgoLeadMe-3/pull/15) | 
 ---

--- a/9-kyo-hwang/다익스트라/22865 가장 먼 곳.txt
+++ b/9-kyo-hwang/다익스트라/22865 가장 먼 곳.txt
@@ -1,0 +1,73 @@
+#include <iostream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+
+using namespace std;
+using edge = pair<int, int>;  // dst, cost
+
+constexpr int INF = 1e9;
+
+int N;
+vector<vector<edge>> adjacent;
+
+vector<int> dijkstra(int s) {
+  vector<int> dists(N + 1, INF);
+  priority_queue<edge, vector<edge>, greater<>> pq;
+
+  dists[s] = 0;
+  pq.emplace(0, s);  // dist, src
+
+  while (!pq.empty()) {
+    const auto [d, u] = pq.top();  // distance, src
+    pq.pop();
+
+    for (const auto &[v, w] : adjacent[u]) {  // dst, weight
+      if (dists[v] > d + w) {
+        dists[v] = d + w;
+        pq.emplace(d + w, v);
+      }
+    }
+  }
+
+  return dists;
+};
+
+int main() {
+  ios_base::sync_with_stdio(false);
+  cin.tie(nullptr), cout.tie(nullptr);
+
+  cin >> N;
+  adjacent.resize(N + 1);
+  
+  int A, B, C;
+  cin >> A >> B >> C;
+
+  int M;
+  cin >> M;
+
+  while (M--) {
+    int D, E, L;
+    cin >> D >> E >> L;
+
+    adjacent[D].emplace_back(E, L);
+    adjacent[E].emplace_back(D, L);
+  }
+
+  vector<vector<int>> dists = {dijkstra(A), dijkstra(B), dijkstra(C)};
+
+  int max_d = 0, answer = 0;
+  for (int i = 1; i <= N; i++) {
+    if (i == A || i == B || i == C) continue;
+
+    int min_d = min({dists[0][i], dists[1][i], dists[2][i]});
+    if (min_d > max_d) {
+      max_d = min_d;
+      answer = i;
+    }
+  }
+
+  cout << answer;
+
+  return 0;
+}


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
<!-- 해결한 문제의 링크를 올려주세요. -->
[22865 가장 먼 곳](https://www.acmicpc.net/problem/22865)

## ✔️ 소요된 시간
<!-- 문제를 해결하는데 소요된 시간을 적어주세요. -->
1시간

## ✨ 수도 코드
<!-- 내가 작성한 코드를 모르는 사람이 봐도 이해할 수 있도록 글로 쉽게 풀어서 설명해주세요. -->
<!-- 알고리즘에 대한 지식이 전혀 없는 사람이 봐도 이해할 수 있도록 작성해주세요. 시각자료를 이용하면 더 좋습니다. -->

이번 차시의 문제는 최단 경로, 그 중에서 single-source 문제이다. 나는 이 문제를 Dijkstra 알고리즘을 이용해 해결했다.

### 1. Single-source 최단경로문제
하나의 출발 노드 s로부터 다른 모든 노드까지의 최단 경로를 찾는 'Single-source' 최단 경로 문제
- 입력: 음수 사이클이 없는 가중치 방향그래프 G=(V, E)와 출발 노드 s $\in$ V
- 목적: 각 노드 v $\in$ V에 대해서 다음을 계산한다.
  - d[v]
    - 처음에는 d[s] = 0, d[v] = $\infty$로 시작한다.
    - 알고리즘이 진행됨에 따라서 감소해간다. 하지만 항상 d[v] $\ge \delta(s, v)$를 유지한다
    - 최종적으로는 d[v] = $\delta(s, v)$가 된다.
  - $\pi$[v]: s에서 v까지의 최단 경로 상에서 v의 직전 노드(predecessor)
    - 그런 노드가 없는 경우 $\pi$[v] = NULL

**기본 연산: Relaxation**
![image](https://github.com/AlgoLeadMe/AlgoLeadMe-3/assets/49135176/552de8f5-2b42-416c-87aa-a5d3dd1371de)

- 대부분의 single-source 최단경로 알고리즘의 기본 구조
  1. 초기화: d[s] = 0, 노드 v $\ne$ s에 대해 d[v] = $\infty$, $\pi$[v] = NULL
  2. 엣지들에 대한 반복적인 relaxation.
- 알고리즘들 간의 차이는 어떤 엣지에 대해, 어떤 순서로 relaxation을 하느냐에 있음

![image](https://github.com/AlgoLeadMe/AlgoLeadMe-3/assets/49135176/760c875c-cb26-4cfa-a5ee-4f52d693b63f)
![image](https://github.com/AlgoLeadMe/AlgoLeadMe-3/assets/49135176/b6fba721-0255-400c-b765-311684a86a3c)

### 2. Dijkstra 알고리즘
- 음수 가정치가 없다고 가정한다.
- s로부터의 최단경로 길이를 이미 알아낸 노드들의 집합 S를 유지한다. 맨 처음엔 S = {s}이다.
- Loop Invariant:
  - u $\notin$ S인 각 노드 u에 대해서 d(u)는 이미 S에 속한 노드들만 거쳐서 s로부터 u까지 가는 최단경로의 길이

  ![image](https://github.com/AlgoLeadMe/AlgoLeadMe-3/assets/49135176/0eb6a70f-8677-45c5-b9c9-6e7f07d5cc21)
- 정리: $d(u)=min_{v\notin S}d(v)$인 노드 u에 대해서, d(u)는 s에서 u까지의 최단경로 길이이다.
  - d(u)가 최소인 노드 u $\notin$ S를 찾고, S에 u 추가
  - S가 변경되었으므로 다른 노드들의 d(v)값 갱신

  ![image](https://github.com/AlgoLeadMe/AlgoLeadMe-3/assets/49135176/19c11550-5fc1-4ebf-992a-888c6862a9bb)
  - d(v) = min{d(v), d(u) + w(u, v)}
  - 즉 엣지 (u, v)에 대해서 relaxation하면 Loop Invariant가 계속 유지됨

![image](https://github.com/AlgoLeadMe/AlgoLeadMe-3/assets/49135176/a6cd471a-ff2c-4ea4-9876-263f9607c789)
![image](https://github.com/AlgoLeadMe/AlgoLeadMe-3/assets/49135176/989b6368-012c-4c29-829d-a6024a5f5f1a)
- 시간복잡도: $O(nlog_2n + mlog_2n)$

### 3. 문제 해설
A 위치에서 나머지 위치까지의 최단거리, B 위치에서 나머지 위치까지의 최단거리, C 위치에서 나머지 위치까지의 최단거리를 각각 구한 뒤, 그 최단거리들 중 '가장 먼 곳'을 찾으면 되는 문제다. "최단거리 중 가장 먼 곳"이라 약간 헷갈릴 수 있다.
```cpp
#include <iostream>
#include <vector>
#include <queue>
#include <algorithm>

using namespace std;
using edge = pair<int, int>;  // dst, cost

constexpr int INF = 1e9;

int N;
vector<vector<edge>> adjacent;

int main() {
  ios_base::sync_with_stdio(false);
  cin.tie(nullptr), cout.tie(nullptr);

  cin >> N;
  adjacent.resize(N + 1);
  
  int A, B, C;
  cin >> A >> B >> C;

  int M;
  cin >> M;

  while (M--) {
    int D, E, L;
    cin >> D >> E >> L;

    adjacent[D].emplace_back(E, L);
    adjacent[E].emplace_back(D, L);
  }

  vector<vector<int>> dists = {dijkstra(A), dijkstra(B), dijkstra(C)};

  int max_d = 0, answer = 0;
  for (int i = 1; i <= N; i++) {
    if (i == A || i == B || i == C) continue;

    int min_d = min({dists[0][i], dists[1][i], dists[2][i]});
    if (min_d > max_d) {
      max_d = min_d;
      answer = i;
    }
  }

  cout << answer;

  return 0;
}
```
골자는 다음과 같다.
- 땅 간 거리는 "인접리스트" 방식으로 저장한다.
- A, B, C 위치에 대해 각각 다익스트라 알고리즘을 수행한다.
- 1번 땅부터 N번 땅까지 순회하며 가장 먼 위치를 찾는다.

```cpp
vector<int> dijkstra(int s) {
  vector<int> dists(N + 1, INF);
  priority_queue<edge, vector<edge>, greater<>> pq;

  dists[s] = 0;
  pq.emplace(0, s);  // dist, src

  while (!pq.empty()) {
    const auto [d, u] = pq.top();  // distance, src
    pq.pop();

    for (const auto &[v, w] : adjacent[u]) {  // dst, weight
      if (dists[v] > d + w) {
        dists[v] = d + w;
        pq.emplace(d + w, v);
      }
    }
  }

  return dists;
};
```
다익스트라 알고리즘 코드는 따른 변형없이 전형적이다. 
- 다만 C++의 경우 우선순위 큐가 'max-heap'이 기본이라 이를 'min-heap'으로 바꿔줬다.

위에서 본 의사 코드에서 보았듯, Q가 빌 때까지 반복하면 최종적으로 거리 계산이 완료되므로, 마지막에 거리 배열 dist를 반환해주는 식으로 함수를 종료한다.

전체코드
```cpp
#include <iostream>
#include <vector>
#include <queue>
#include <algorithm>

using namespace std;
using edge = pair<int, int>;  // dst, cost

constexpr int INF = 1e9;

int N;
vector<vector<edge>> adjacent;

vector<int> dijkstra(int s) {
  vector<int> dists(N + 1, INF);
  priority_queue<edge, vector<edge>, greater<>> pq;

  dists[s] = 0;
  pq.emplace(0, s);  // dist, src

  while (!pq.empty()) {
    const auto [d, u] = pq.top();  // distance, src
    pq.pop();

    for (const auto &[v, w] : adjacent[u]) {  // dst, weight
      if (dists[v] > d + w) {
        dists[v] = d + w;
        pq.emplace(d + w, v);
      }
    }
  }

  return dists;
};

int main() {
  ios_base::sync_with_stdio(false);
  cin.tie(nullptr), cout.tie(nullptr);

  cin >> N;
  adjacent.resize(N + 1);
  
  int A, B, C;
  cin >> A >> B >> C;

  int M;
  cin >> M;

  while (M--) {
    int D, E, L;
    cin >> D >> E >> L;

    adjacent[D].emplace_back(E, L);
    adjacent[E].emplace_back(D, L);
  }

  vector<vector<int>> dists = {dijkstra(A), dijkstra(B), dijkstra(C)};

  int max_d = 0, answer = 0;
  for (int i = 1; i <= N; i++) {
    if (i == A || i == B || i == C) continue;

    int min_d = min({dists[0][i], dists[1][i], dists[2][i]});
    if (min_d > max_d) {
      max_d = min_d;
      answer = i;
    }
  }

  cout << answer;

  return 0;
}
```

## 📚 새롭게 알게된 내용
<!-- 새롭게 알게된 내용이 있다면 작성 해주시고 출처를 남겨주세요. -->
다익스트라도 간만에 해보니 엄청 버벅였다...
다음 차시부터는 여러분도 이해할 만한 문제로 들고와보겠습니다 ㅋㅋ