### PR TITLE
8-9kyo-hwang

### DIFF
--- a/9-kyo-hwang/README.md
+++ b/9-kyo-hwang/README.md
@@ -8,5 +8,6 @@
 | 4차시 | 2023.11.14 | 트라이 | [5052 전화번호 목록](https://www.acmicpc.net/problem/5052) | [#11](https://github.com/AlgoLeadMe/AlgoLeadMe-3/pull/11) | 
 | 5차시 | 2023.11.17 | 플로이드-워셜 | [1613 역사](https://www.acmicpc.net/problem/1613) | [#15](https://github.com/AlgoLeadMe/AlgoLeadMe-3/pull/15) | 
 | 6차시 | 2023.11.19 | 다익스트라 | [22865 가장 먼 곳](https://www.acmicpc.net/problem/22865) | [#19](https://github.com/AlgoLeadMe/AlgoLeadMe-3/pull/19) | 
-| 7차시 | 2023.11.20 | 분리 집합 | [10775 공항](https://www.acmicpc.net/problem/10775) | [#23](https://github.com/AlgoLeadMe/AlgoLeadMe-3/pull/24) | 
+| 7차시 | 2023.11.20 | 분리 집합 | [10775 공항](https://www.acmicpc.net/problem/10775) | [#24](https://github.com/AlgoLeadMe/AlgoLeadMe-3/pull/24) | 
+| 8차시 | 2023.11.24 | 백트래킹 | [16987 계란으로 계란치기](https://www.acmicpc.net/problem/16987) | [#27](https://github.com/AlgoLeadMe/AlgoLeadMe-3/pull/27) | 
 ---

--- a/9-kyo-hwang/백트래킹/16987 계란으로 계란치기.txt
+++ b/9-kyo-hwang/백트래킹/16987 계란으로 계란치기.txt
@@ -1,0 +1,56 @@
+#include <iostream>
+#include <vector>
+#include <algorithm>
+
+using namespace std;
+using Egg = pair<int,int>;  // S, W
+
+#define S first
+#define W second
+
+int N;
+vector<Egg> eggs;
+
+int backtracking(int current = 0, int broken = 0) {
+  // 가장 오른쪽 끝 계란에 도달했다면 지금까지 부순 계란의 개수 반환
+  if (current == N) {
+    return broken;
+  }
+
+  // 현재 계란이 깨졌거나 모든 계란이 깨졌다면, 계란을 치지 않고 넘어감.
+  if (eggs[current].S <= 0 || broken == N - 1) {
+    return backtracking(current + 1, broken);
+  }
+
+  int count = 0;
+  for (int next = 0; next < N; next++) {
+    // 다음으로 깨는 계란이 자기 자신이거나 이미 깨졌다면 수행하지 않음
+    if (current == next || eggs[next].S <= 0) continue;
+
+    eggs[current].S -= eggs[next].W;
+    eggs[next].S -= eggs[current].W;
+
+    // 모든 백트래킹의 경우에 대해 가장 큰 값을 취함
+    count = max(count, backtracking(current + 1, broken + (eggs[current].S <= 0) + (eggs[next].S <= 0)));
+
+    eggs[current].S += eggs[next].W;
+    eggs[next].S += eggs[current].W;
+  }
+
+  return count;
+}
+
+int main() {
+  ios::sync_with_stdio(false);
+  cin.tie(nullptr);
+  cout.tie(nullptr);
+
+  cin >> N;
+  eggs.resize(N);
+  
+  for (auto &[S, W] : eggs) cin >> S >> W;
+
+  cout << backtracking();
+
+  return 0;
+}


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
<!-- 해결한 문제의 링크를 올려주세요. -->
[16987 계란으로 계란치기](https://www.acmicpc.net/problem/16987)

## ✔️ 소요된 시간
<!-- 문제를 해결하는데 소요된 시간을 적어주세요. -->
1시간

## ✨ 수도 코드
<!-- 내가 작성한 코드를 모르는 사람이 봐도 이해할 수 있도록 글로 쉽게 풀어서 설명해주세요. -->
<!-- 알고리즘에 대한 지식이 전혀 없는 사람이 봐도 이해할 수 있도록 작성해주세요. 시각자료를 이용하면 더 좋습니다. -->

### 1. 문제 파악
N개의 계란이 주어진다. 각 계란은 [내구도(S), 무게(W)]를 가지고 있다. 그리고 계란끼리 치면 무게만큼 내구도가 감소한다. 예를 들어
- 계란 1: 내구도 7, 무게 5 / 계란 2: 내구도 3, 무게 4
- 이 때 계란 1이 계란 2를 치면 
  - 계란 2의 내구도는 3-5=-2로 감소하며 깨지고
  - 계란 1은 내구도 7-4=3으로 감소한다.

다음과 같은 전략으로 퍼즐을 해결한다.
1. 가장 왼쪽 계란을 든다.
2. 손에 들고 있는 계란으로 깨지지 않은 다른 계란 중 하나를 친다. 단, 아래의 경우에는 계란을 치지 않고 넘어간다.
  i. 손에 든 계란이 깨졌거나
  ii. 깨지지 않은 다른 계란이 없거나
3. 가장 최근에 든 계란의 한 칸 오른쪽 계란을 손에 들고 2번 과정을 반복한다. 만약 가장 최근에 든 계란이 가장 오른쪽 계란이라면 진행을 멈춘다.

입력은 다음과 같이 주어진다.
- 계란 개수 $1 \le N \le 8$
- N개의 계란 정보(내구도 $1 \le S_i \le 300$, 무게 $1 \le W_i \le 300$)

### 2. 문제 풀이
1번 계란으로 2번 계란을 **치냐/안치냐** , 1번 계란으로 2번 ~ N번 계란 중 **어떤 걸 치냐** 에 따라서  많은 경우의 수가 갈라진다. 보통 이런 경우 재귀를 이용한 **백트래킹(Backtracking)** 전략이 사용되는데, 이 문제가 그렇다.

추가로, 계란 개수가 최대 **8개** 까지 밖에 주어지지 않는다. 개수가 보통 이렇게 적은 경우 **모든 경우를 다 탐색(brute-force)** 하는 경우인데, 이 문제 역시 그렇다.

![image](https://github.com/AlgoLeadMe/AlgoLeadMe-3/assets/49135176/f111191d-3cad-4674-9157-58af9560d31f)

문제에서 퍼즐을 해결하는 로직을 친절하게 제시해줬으니, 백트래킹+완전탐색 정보를 기반으로 차근차근 코드를 작성해보자.

```cpp
#include <iostream>
#include <vector>
#include <algorithm>

using namespace std;
using Egg = pair<int,int>;  // S, W

#define S first
#define W second

int N;
vector<Egg> eggs;

int backtracking() { ... }

int main() {
  ios::sync_with_stdio(false);
  cin.tie(nullptr);
  cout.tie(nullptr);

  cin >> N;
  eggs.resize(N);
  
  for (auto &[S, W] : eggs) cin >> S >> W;

  cout << backtracking();

  return 0;
}
```
메인 함수에서는 계란의 개수 N을 입력받고, 다시 N개의 계란에 대한 정보를 입력받아 eggs에 저장한다.
그리고 backtracking을 호출해 그 결과를 출력한다.

```cpp
int backtracking(int current = 0, int broken = 0) {
  if (current == N) { 
    return broken;
  }

  if (eggs[current].S <= 0 || broken == N - 1) {
    return backtracking(current + 1, broken);
  }

  int count = 0;
  for (int next = 0; next < N; next++) { 
    if (current == next || eggs[next].S <= 0) continue;

    eggs[current].S -= eggs[next].W;
    eggs[next].S -= eggs[current].W;

    count = max(count, backtracking(current + 1, broken + (eggs[current].S <= 0) + (eggs[next].S <= 0)));

    eggs[current].S += eggs[next].W;
    eggs[next].S += eggs[current].W;
  }

  return count;
}
```
이 문제의 핵심인 백트래킹 함수이다.
매개변수로 현재 들고 있는 계란의 인덱스를 나타내는 current와, 지금까지 부순 계란의 개수 broken을 받는다.

재귀함수는 **Base case** 와 **Recursive case** 가 존재해야 한다.
- Base case: recursion에 빠지지 않는 케이스. 적어도 하나는 존재해야 한다.
- Recursive case: 자기 자신을 다시 부르는 케이스. 최종적으로 Base case로 수렴해야 한다.

첫 번째 if문이 Base case에 해당한다.
```cpp
if (current == N) {  // 3. 최근에 든 계란이 가장 오른쪽 계란이었다면
  return broken;
}
```
퍼즐 로직 3번째 "현재 들고 있는 계란이 가장 오른쪽 것이라면"에 해당하는 케이스로, 지금까지 부순 계란 개수를 반환함으로 재귀를 빠져나온다.

두 번째 if문은 로직 2번째에 해당하는데, 이 경우에는 다른 계란을 치는 것이 불가능하므로 "지금 계란의 오른쪽 계란(current + 1)"을 가지고 수행한 재귀의 결과를 반환한다.
```cpp
if (eggs[current].S <= 0 || broken == N - 1) {  // 2. 손에 든 계란이 깨졌거나 모든 계란이 깨졌다면
  return backtracking(current + 1, broken);
}
```

for문에 도달하면 현재 계란을 가지고 다른 계란 치기를 시도한다.
```cpp
int count = 0;
for (int next = 0; next < N; next++) {  // 
  if (current == next || eggs[next].S <= 0) continue;

  eggs[current].S -= eggs[next].W;
  eggs[next].S -= eggs[current].W;

  count = max(count, backtracking(current + 1, broken + (eggs[current].S <= 0) + (eggs[next].S <= 0)));

  eggs[current].S += eggs[next].W;
  eggs[next].S += eggs[current].W;
}
return count;
```
여기서 애를 먹었는데, "완전탐색"의 가능성을 깜빡하고 문제의 "가장 왼쪽 계란" 정보만 생각하고 for문의 반복 범위를 **current + 1** 부터 시작하도록 해버려서 삽질을 좀 했다.
각각의 계란이 어떤 계란을 치냐에 따라서, 그 다음 재귀 호출에서 칠 수 있는 계란의 정보가 달라지기 때문에 각각의 재귀에서 모든 계란에 대해 확인해봐야 한다.

만약 다음 계란(next)이 지금 들고 있는 계란(current)와 동일하거나, 다음 계란이 이미 깨져있는 경우(eggs[next].S <= 0)는 시도하지 않도록 예외처리를 한 뒤, 하나씩 계란을 쳐본다.
```cpp
// 부술 계란이 (1) 자기 자신이거나 (2) 이미 깨져있다면 진행하지 않음
if (current == next || eggs[next].S <= 0) continue;
```

다음 재귀 호출 또한 무수히 많은 결과를 반환해줄 것인데, 그 중 **가장 큰 값** 을 취한다. 즉, Base case에서 반환하는 broken 개수 중 가장 큰 값을 취하는 것이다.
```cpp
count = max(count, backtracking(current + 1, broken + (eggs[current].S <= 0) + (eggs[next].S <= 0)));
```

for문을 완료하면 최종적으로 현재 재귀 호출에서 가장 큰 값을 return해주면 완성이다.
```cpp
return count;
```

### 전체 소스 코드
```cpp
#include <iostream>
#include <vector>
#include <algorithm>

using namespace std;
using Egg = pair<int,int>;

#define S first
#define W second

int N;
vector<Egg> eggs;

int backtracking(int current = 0, int broken = 0) {
  if (current == N) {
    return broken;
  }

  if (eggs[current].S <= 0 || broken == N - 1) { 
    return backtracking(current + 1, broken);
  }

  int count = 0;
  for (int next = 0; next < N; next++) {  // 
    if (current == next || eggs[next].S <= 0) continue;

    eggs[current].S -= eggs[next].W;
    eggs[next].S -= eggs[current].W;

    count = max(count, backtracking(current + 1, broken + (eggs[current].S <= 0) + (eggs[next].S <= 0)));

    eggs[current].S += eggs[next].W;
    eggs[next].S += eggs[current].W;
  }

  return count;
}

int main() {
  ios::sync_with_stdio(false);
  cin.tie(nullptr);
  cout.tie(nullptr);

  cin >> N;
  eggs.resize(N);
  
  for (auto &[S, W] : eggs) cin >> S >> W;

  cout << backtracking();

  return 0;
}
```
![image](https://github.com/AlgoLeadMe/AlgoLeadMe-3/assets/49135176/a4948278-ee98-4272-bf70-277ecdcf8918)

## 📚 새롭게 알게된 내용
<!-- 새롭게 알게된 내용이 있다면 작성 해주시고 출처를 남겨주세요. -->
백트래킹 문제는 자료구조-알고리즘 수업에 여지껏 PS하면서 몇 문제를 풀었는데도 어렵다
당장 이 문제도 1시간 삽질 거하게 하고 다른 포스트 참고하자마자 풀려버렸다...
결국 맨날 짜던 그 코드 틀과 별 차이도 없는데 ㅜ
계속 연습해야지 😢