### PR TITLE
13-Dolchae

### DIFF
--- a/Dolchae/README.md
+++ b/Dolchae/README.md
@@ -14,3 +14,4 @@
 | 10차시| 2023.11.29 |  구현  | [7568 덩치](https://www.acmicpc.net/problem/7568)       | [#36](https://github.com/AlgoLeadMe/AlgoLeadMe-3/pull/36) |
 | 11차시| 2023.12.25 |  수학  | [1735 분수 합](https://www.acmicpc.net/problem/1735)    | [#39](https://github.com/AlgoLeadMe/AlgoLeadMe-3/pull/39) |
 | 12차시| 2023.12.27 |  스택  | [1406 에디터](https://www.acmicpc.net/problem/1406)    | [#43](https://github.com/AlgoLeadMe/AlgoLeadMe-3/pull/43) |
+| 13차시| 2023.12.29 |  구현  | [1158 요세푸스 문제](https://www.acmicpc.net/problem/1158) | [#46](https://github.com/AlgoLeadMe/AlgoLeadMe-3/pull/46) |

--- a/Dolchae/구현/1158 요세푸스 문제.py
+++ b/Dolchae/구현/1158 요세푸스 문제.py
@@ -1,0 +1,12 @@
+input_ = open(0).readline
+num, order = map(int,input_().split())
+list = [i+1 for i in range(num)]
+ans_list = []
+count = 0
+while True:
+    if len(list)==0:
+        break
+    count = (count+order-1)%len(list)
+    ans_list.append(list.pop(count))
+
+print(f"<{', '.join(map(str,ans_list))}>")


### PR DESCRIPTION
## 🔗 문제 링크
[1158 요세푸스 문제](https://www.acmicpc.net/problem/1158)

## ✔️ 소요된 시간
40분

## ✨ 수도 코드
## 문제 설명
N명의 사람들이 원으로 앉아있고, 입력된 K번째 사람을 제거하는 순서를 출력하는 문제이다.

## 코드 설명
```python
input_ = open(0).readline
num, order = map(int,input_().split())
list = [i+1 for i in range(num)]
ans_list = []
count = 0
```
- num에 사람의 수와 order에 k번째의 k를 입력받는다.
- 1부터 num까지의 리스트를 list에 저장한다.
- 나중에 출력할 정답 리스트인 ans_list를 만든다.
- count는 list에서 pop하고 ans_list에 append 할, k번째 사람의 인덱스를 나타낼 변수이다.
<br>

```python
while True:
    if len(list)==0:
        break
    count = (count+order-1)%len(list)
    ans_list.append(list.pop(count))

print(f"<{', '.join(map(str,ans_list))}>")
```
- while문을 실행하며 list의 길이가 0이 되면 즉, 사람이 0명이 되면 break 되도록 한다.
- (count+order-1)의 연산으로 count는 제거해야 할 다음 인덱스를 가리키게 되고, %len(list)로 다음 인덱스가 리스트의 길이를 넘어갔을 때 다시 처음부터 시작될 수 있도록 한다.
- count를 list에서 pop하고 ans_list에 저장한다.
- 마지막으로 ans_list를 출력형식에 맞춰 출력한다.
<br>
<br>

### 전체 코드
```python
input_ = open(0).readline
num, order = map(int,input_().split())
list = [i+1 for i in range(num)]
ans_list = []
count = 0
while True:
    if len(list)==0:
        break
    count = (count+order-1)%len(list)
    ans_list.append(list.pop(count))

print(f"<{', '.join(map(str,ans_list))}>")

```

## 📚 새롭게 알게된 내용
join함수를 쓸 때 str+int를 해놓고 왜 오류가 나는지 못 찾았다. 그리고 생각보다 count식을 찾는 데에 시간을 많이 걸려서 당황스러웠다..🥲