### PR TITLE
9-gjsk132

### DIFF
--- a/gjsk132/BFS/10026 적록색약.py
+++ b/gjsk132/BFS/10026 적록색약.py
@@ -6,7 +6,7 @@ size = int(input())
 area = [list(input().strip()) for i in range(size)]
 blind = [['G' if j=='R' else j for j in i] for i in area]
 
-def bfs(x, y, color):
+def dfs(x, y, color):
     area[x][y] = 'X'
     for dx, dy in zip([-1,0,1,0],[0,1,0,-1]):
         nx = x+dx
@@ -15,7 +15,7 @@ def bfs(x, y, color):
             continue
         if not area[nx][ny] == color:
             continue
-        bfs(nx,ny,color)
+        dfs(nx,ny,color)
         
 def findarea():
     cnt = 0
@@ -24,7 +24,7 @@ def findarea():
             if area[i][j] == 'X':
                 continue
             cnt += 1
-            bfs(i,j,area[i][j])
+            dfs(i,j,area[i][j])
     print(cnt, end=" ")
     
 findarea()

--- a/gjsk132/BFS/10026 적록색약.py
+++ b/gjsk132/BFS/10026 적록색약.py
@@ -1,0 +1,32 @@
+import sys
+sys.setrecursionlimit(10**6)
+
+input = open(0).readline
+size = int(input())
+area = [list(input().strip()) for i in range(size)]
+blind = [['G' if j=='R' else j for j in i] for i in area]
+
+def bfs(x, y, color):
+    area[x][y] = 'X'
+    for dx, dy in zip([-1,0,1,0],[0,1,0,-1]):
+        nx = x+dx
+        ny = y+dy
+        if nx < 0 or ny < 0 or nx == size or ny == size:
+            continue
+        if not area[nx][ny] == color:
+            continue
+        bfs(nx,ny,color)
+        
+def findarea():
+    cnt = 0
+    for i in range(size):
+        for j in range(size):
+            if area[i][j] == 'X':
+                continue
+            cnt += 1
+            bfs(i,j,area[i][j])
+    print(cnt, end=" ")
+    
+findarea()
+area = blind
+findarea()

--- a/gjsk132/README.md
+++ b/gjsk132/README.md
@@ -8,4 +8,5 @@
 | 6차시 | 2023.11.24 | BFS | [7576 토마토](https://www.acmicpc.net/problem/7576) | - |
 | 7차시 | 2023.11.27 | 그리디 | [16953 A → B](https://www.acmicpc.net/problem/16953) | - |
 | 8차시 | 2023.11.29 | DP | [1463 1로 만들기](https://www.acmicpc.net/problem/1463) | - |
+| 9차시 | 2024.01.03 | BFS | [10026 적록색약](https://www.acmicpc.net/problem/10026) | - |
 ---


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
[백준 10026 : 적록색약](https://www.acmicpc.net/problem/10026)
<!-- 해결한 문제의 링크를 올려주세요. -->

## ✔️ 소요된 시간
<!-- 문제를 해결하는데 소요된 시간을 적어주세요. -->
35분
## ✨ 수도 코드

### 문제 이해
**1. 적록색약인 경우와 아닌 경우 2가지의 데이터**
<img src="https://github.com/AlgoLeadMe/AlgoLeadMe-3/assets/113815454/c395ca2d-d3ce-4280-bf2c-8136a1748820" width=400>
<img src="https://github.com/AlgoLeadMe/AlgoLeadMe-3/assets/113815454/48dc1445-a297-4881-b368-1bca9752a51d" width=400>
적록색약인 경우에는 빨간색과 초록색은 같은 색상으로 보고 하기 때문에, 둘 중 아무거나 하나로 통일시켜준다.

위와 같이 2가지 데이터를 각각 영역의 수를 세주면 된다.

### 코드 설명

전체 크기와 색상 데이터를 입력받는다.
```py
size = int(input())
area = [list(input().strip()) for i in range(size)]
```
적록색약이 보는 색상 데이터를 새롭게 정의해준다.
```py
blind = [['G' if j=='R' else j for j in i] for i in area]
```

하나의 색상 구역을 전부 체크해주는 함수
```py
def dfs(x, y, color):
    # 입력된 위치를 체크
    area[x][y] = 'X'
    # 상하좌우 4방향 확인
    for dx, dy in zip([-1,0,1,0],[0,1,0,-1]):
        nx = x+dx
        ny = y+dy
        if nx < 0 or ny < 0 or nx == size or ny == size:
            continue
        if not area[nx][ny] == color:
            continue
        # 탐색하려는 위치가 전체 크기를 벗어나지 않고, 같은 색상이라면 다음 위치에서 dfs
        dfs(nx,ny,color)
```

전체 색상 데이터를 탐색하는 함수
```py
def findarea():
    cnt = 0
    for i in range(size):
        for j in range(size):
            # 만약 이미 탐색한 영역이라면 다음 위치로
            if area[i][j] == 'X':
                continue
           # 탐색하지 않은 영역이라면?
           # 영역의 수를 +1 해주고, 해당 영역을 dfs를 통해 체크하기.
            cnt += 1
            dfs(i,j,area[i][j])
    # 결과 출력하기
    print(cnt, end=" ")
```

위 두 가지 함수와 2가지 색상 데이터를 이용해서
적록색약이 아닌 경우 -> findarea()함수를 통해 결과 출력
적록색약인 경우 -> blind를 area로 대입해줘서 findarea()함수를 통해 결과 출력
```py
findarea()
area = blind
findarea()
```

<details>
<summary>전체 코드</summary>
<div markdown="1">

```py
import sys
sys.setrecursionlimit(10**6)

input = open(0).readline
size = int(input())
area = [list(input().strip()) for i in range(size)]
blind = [['G' if j=='R' else j for j in i] for i in area]

def dfs(x, y, color):
    area[x][y] = 'X'
    for dx, dy in zip([-1,0,1,0],[0,1,0,-1]):
        nx = x+dx
        ny = y+dy
        if nx < 0 or ny < 0 or nx == size or ny == size:
            continue
        if not area[nx][ny] == color:
            continue
        dfs(nx,ny,color)
        
def findarea():
    cnt = 0
    for i in range(size):
        for j in range(size):
            if area[i][j] == 'X':
                continue
            cnt += 1
            dfs(i,j,area[i][j])
    print(cnt, end=" ")
    
findarea()
area = blind
findarea()
```

</div>
</details>

## 📚 새롭게 알게된 내용
<!-- 새롭게 알게된 내용이 있다면 작성 해주시고 출처를 남겨주세요. -->

파이썬 최대 재귀 횟수는 제한되어 있어서 _RecursionError_ 가 발생하게되는데, 아래 코드를 이용하면 재귀를 원하는 범위만큼 제한 해제할 수 있다. 
```py
import sys
sys.setrecursionlimit(10**6)
```
흠... 재귀 범위를 손대지 않고 할 수 있는 법이 따로 있을까요..?
