### PR TITLE
24-9kyo-hwang

### DIFF
--- a/9-kyo-hwang/README.md
+++ b/9-kyo-hwang/README.md
@@ -24,3 +24,4 @@
 | 21차시 | 2024.1.18  | Graph Traversal            | [16947 서울 지하철 2호선](https://www.acmicpc.net/problem/16947)  | [#75](https://github.com/AlgoLeadMe/AlgoLeadMe-3/pull/75) |
 | 22차시 | 2024.1.21  | Two Pointers               | [1981 배열에서 이동](https://www.acmicpc.net/problem/1981)        | [#79](https://github.com/AlgoLeadMe/AlgoLeadMe-3/pull/79) |
 | 23차시 | 2024.1.24  | Disjoint Set               | [표 병함](https://school.programmers.co.kr/learn/courses/30/lessons/150366)        | [#81](https://github.com/AlgoLeadMe/AlgoLeadMe-3/pull/81) |
+| 24차시 | 2024.1.28  | Tree                       | [표현 가능한 이진트리](https://school.programmers.co.kr/learn/courses/30/lessons/150367)        | [#92](https://github.com/AlgoLeadMe/AlgoLeadMe-3/pull/92) |

--- a/9-kyo-hwang/Tree/2023 KAKAO BLIND RECRUITMENT 표현 가능한 이진트리.cpp
+++ b/9-kyo-hwang/Tree/2023 KAKAO BLIND RECRUITMENT 표현 가능한 이진트리.cpp
@@ -1,0 +1,42 @@
+#include <string>
+#include <vector>
+#include <bitset>
+
+using namespace std;
+
+bool can_expressed_as_tree(string binary) {
+    if(binary.size() <= 1) {
+        return true;
+    }
+    
+    int mid = binary.size() / 2;
+    if(binary[mid] == '0' && binary.find('1') != string::npos) {
+        return false;
+    }
+    
+    return can_expressed_as_tree(binary.substr(0, mid)) && can_expressed_as_tree(binary.substr(mid + 1));
+}
+
+string decimal_to_binary(long long& number) {
+    string s = bitset<64>(number).to_string();
+    s = s.substr(s.find('1'));
+    
+    int bin = 1;
+    while(s.size() >= bin) {
+        bin *= 2;
+    }
+    
+    for(int repeat = bin - 1 - s.size(); repeat > 0; --repeat) {
+        s = '0' + s;
+    }
+    
+    return s;
+}
+
+vector<int> solution(vector<long long> numbers) {
+    vector<int> answer;
+    for(long long& number : numbers) {
+        answer.emplace_back(can_expressed_as_tree(decimal_to_binary(number)));
+    }
+    return answer;
+}


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
<!-- 해결한 문제의 링크를 올려주세요. -->

2023 KAKAO BLIND RECRUITMENT 문제 4 - [표현 가능한 이진트리](https://school.programmers.co.kr/learn/courses/30/lessons/150367)

## ✔️ 소요된 시간
<!-- 문제를 해결하는데 소요된 시간을 적어주세요. -->

1시간 + a

## ✨ 수도 코드
<!-- 내가 작성한 코드를 모르는 사람이 봐도 이해할 수 있도록 글로 쉽게 풀어서 설명해주세요. -->
<!-- 알고리즘에 대한 지식이 전혀 없는 사람이 봐도 이해할 수 있도록 작성해주세요. 시각자료를 이용하면 더 좋습니다. -->

### 1. 문제

다음과 같은 이진트리가 존재한다고 가정하자.
![image](https://github.com/AlgoLeadMe/AlgoLeadMe-3/assets/49135176/09641883-ae6c-4d7f-a6ac-41b8fc7132cd)

주어진 이진트리에 더미 노드를 추가해 포화 이진트리를 만들면 다음과 같다. 더미 노드는 점선으로 표시했으며, 노드 안의 숫자는 살펴보는 순서를 의미한다.
![image](https://github.com/AlgoLeadMe/AlgoLeadMe-3/assets/49135176/a2b5ea0d-616b-4aec-9740-544e0afd4b89)

노드들을 왼쪽에 있는 순서대로 살펴보며 0(더미 노드), 1(실제 노드)을 사용해 문자열로 표현하면 "0111010"이 된다. 이 이진수를 십진수로 변환하면 58이다.

정수 배열 numbers가 주어졌을 때, 해당 수들을 이진트리로 표현할 수 있다면 1/없다면 0을 1차원 정수 배열에 담아 return하도록 solution 함수를 완성하라.

### 2. 풀이

#### 1. 적절한 2진수로 변환
이진트리로 수를 표현하려면 0, 1로 이루어진 문자열이 필요하기 때문에, 우선 10진수를 2진수로 변환한다.

여러가지 방법이 있겠지만, 여기서는 C++이 제공하는 'bitset' 라이브러리를 사용하였다.
```cpp
string decimal_to_binary(int64& number) {  // using int64 = long long;
    string s = bitset<64>(number).to_string();
    s = s.substr(s.find('1'));
    ...
}
```
주어지는 수가 최대 $10^{15}$이라, int64 범위까지 확인해야 하기 때문에 64비트 길이로 정의한다.
예를 들어, 42이라는 숫자가 주어지면 ```0000000000000000000000000000000000000000000000000000000000101010```으로 구한 뒤 '1'이 시작하는 위치를 찾아 해당 위치부터 끝까지 부분 문자열로 취해 ```101010```을 얻는 방식이다.

포화 이진트리는 3개, 7개, 15개, ...와 같은 $2^n - 1$개의 노드를 가진다. 즉 2진수를 포화 이진트리로 표현하려면 2진수 문자열의 길이가 $2^n - 1$이어야 한다. 
위의 42라는 숫자는 이진수로 표현하면 '101010'인데, 이 숫자로는 포화 이진트리로 바로 표현할 수 없다. 
![001](https://github.com/AlgoLeadMe/AlgoLeadMe-3/assets/49135176/426e92c1-bc9d-455d-bbce-33458c8756ff)

따라서 $2^n-1$ 길이를 맞춰주기 위해 문자열 앞에 적절한 개수의 '0'을 덧붙여줄 필요가 있다.
'101010'의 경우 앞에 0을 하나 추가한 '0101010'로 만듦으로써, 노드 개수가 7개인 포화 이진노드로 표현할 수 있다. 
![002](https://github.com/AlgoLeadMe/AlgoLeadMe-3/assets/49135176/f3a08641-6e3c-4c0c-91eb-501c1179bb0a)

즉 주어진 수를 표현하는 포화 이진트리는 **2진수 문자열 길이에 가장 가까우면서 크거나 같은 2의 지수 - 1**개의 노드를 갖게 된다.
```cpp
string decimal_to_binary(int64& number) {
    ...
    int bin = 1;
    while(s.size() >= bin) {
        bin *= 2;
    }
    
    for(int repeat = bin - 1 - s.size(); repeat > 0; --repeat) {
        s = '0' + s;
    }
    
    return s;
}
```
위 코드에서 2의 지수가 bin인데, (bin - 1)개에서 문자열 길이 ```s.size()```을 뺀 만큼 0을 덧붙이면 된다.
101010의 경우 문자열 길이가 6(=s.size())이며, 가장 가까운 2의 지수는 8(=bin)이다. 따라서 (8 - 1 - 6 = 1)개 만큼 0을 덧붙이게 된다.

최종적으로 전처리가 완료된 2진수 문자열 s를 반환해주면 된다.

#### 2. 판별
1번 과정에서 받은 2진수 문자열을 이용해, 포화 이진트리로 표현 가능한 지 검사한다. 트리로 표현이 가능한 지 확인하려면 부모 - 자식 노드의 연결을 확인하면 된다.
부모 노드는 자식 노드를 가져도 되고 가지지 않아도 된다. **하지만 자식 노드는 반드시 부모 노드가 존재해야 한다.**

숫자 5가 주어졌다고 가정하자. 이 숫자는 2진수로 표현하면 '101'이다. 문자열 길이가 $2^n - 1$이므로 바로 포화 이진트리로 그려볼 수 있다.
![제목을 입력해주세요_-003](https://github.com/AlgoLeadMe/AlgoLeadMe-3/assets/49135176/6f51829f-a929-4bc8-8fa3-3c4f7720919a)

하지만 부모 노드가 더미, 즉 존재하지 않는데 자식 노드가 존재하는 꼴이 된다. 이런 수는 포화 이진트리로 표현할 수 없다.

즉 **부모가 더미이면서(==0) 자식 중에 더미가 아닌 노드(==1)가 하나라도 있는 경우** 불가능하다는 것을 알 수 있다.
이를 재귀적으로 서브트리로 내려가면서 리프 노드까지 검사하면 된다.

```cpp
bool can_expressed_as_tree(string binary) {
    if(binary.size() <= 1) {
        return true;
    }
    
    int mid = binary.size() / 2; 
    if(binary[mid] == '0' && binary.find('1') != string::npos) {
        return false;
    }
    
    return can_expressed_as_tree(binary.substr(0, mid)) && can_expressed_as_tree(binary.substr(mid + 1));
}
```
2진수 문자열의 정가운데가 항상 루트 노드이므로 해당 위치를 기준으로 검사한다. 만약 루트가 더미(==0)이면서 문자열 내부에 1이 하나라도 존재한다면 즉시 return false로 한다.

그게 아니라면 substr 함수를 이용해 루트 기준 왼쪽 부분 문자열과 오른쪽 부분 문자열에 대해 재귀적으로 함수를 호출해, 둘 다 참이면 return true가 되도록 했다.

만약 부분 문자열의 길이가 1이 됐다면, 이는 리프 노드를 의미하므로 0이든 1이든 상관없이 return true를 해주면 된다.

```cpp
vector<int> solution(vector<int64> numbers) {
    vector<int> answer;
    for(int64& number : numbers) {
        answer.emplace_back(can_expressed_as_tree(decimal_to_binary(number)));
    }
    return answer;
}
```
최종적으로 solution에서는 numbers에서 숫자를 하나씩 꺼내 2진수로 변환 -> 변환한 숫자로 검사 -> 검사 결과를 answer에 저장하는 과정을 거친다.

### 전체 코드
```cpp
#include <string>
#include <vector>
#include <bitset>

using namespace std;
using int64 = long long;

bool can_expressed_as_tree(string binary) {
    if(binary.size() <= 1) {
        return true;
    }
    
    int mid = binary.size() / 2;
    if(binary[mid] == '0' && binary.find('1') != string::npos) {
        return false;
    }
    
    return can_expressed_as_tree(binary.substr(0, mid)) && can_expressed_as_tree(binary.substr(mid + 1));
}

string decimal_to_binary(int64& number) {
    string s = bitset<64>(number).to_string();
    s = s.substr(s.find('1'));
    
    int bin = 1;
    while(s.size() >= bin) {
        bin *= 2;
    }
    
    for(int repeat = bin - 1 - s.size(); repeat > 0; --repeat) {
        s = '0' + s;
    }
    
    return s;
}

vector<int> solution(vector<int64> numbers) {
    vector<int> answer;
    for(int64& number : numbers) {
        answer.emplace_back(can_expressed_as_tree(decimal_to_binary(number)));
    }
    return answer;
}
```

## 📚 새롭게 알게된 내용
<!-- 새롭게 알게된 내용이 있다면 작성 해주시고 출처를 남겨주세요. -->
처음 문제 봤을 때 멍...해졌었다. "이게 뭐지?" 한참 갈팡질팡하다가 빡집중하니 겨우 문제 이해가 됐다(ㅋㅋ...).

포화 이진트리 노드 개수로 맞추기 위해 0을 덧붙이는 과정에서 애를 좀 먹었다. 결국 질문하기 게시판의 도움을 받았다(흑 ㅠ).

카카오는 참 희한한 문제 잘 들고온단 말이지...