### PR TITLE
25-gjsk132

### DIFF
--- a/gjsk132/Prefix Sum/21758 꿀 따기.py
+++ b/gjsk132/Prefix Sum/21758 꿀 따기.py
@@ -1,0 +1,21 @@
+input = open(0).readline
+
+place = int(input())
+honey = list(map(int,input().split()))
+total = sum(honey)
+
+def side_beehive():
+    honey_sum = [i for i in honey]
+
+    for p in range(1, place):
+        honey_sum[p] += honey_sum[p-1]
+    
+    return (total*2 - min([honey[i]+honey_sum[i] for i in range(1,place-1)]) - honey[0])
+
+beehive = total - honey[-1] - honey[0] + max(honey)
+
+beehive = max(beehive, side_beehive())
+honey.reverse()
+beehive = max(beehive, side_beehive())
+
+print(beehive)

--- a/gjsk132/README.md
+++ b/gjsk132/README.md
@@ -23,3 +23,4 @@
 | 21차시 | 2024.02.11 | DP | [3067 Coins](https://www.acmicpc.net/problem/3067) | [🪙](https://github.com/AlgoLeadMe/AlgoLeadMe-3/pull/102) |
 | 22차시 | 2024.02.15 | Brute Froce | [1107 리모컨](https://www.acmicpc.net/problem/1107) | [📲](https://github.com/AlgoLeadMe/AlgoLeadMe-3/pull/106) |
 | 23차시 | 2024.02.27 | Sort | [18870 좌표 압축](https://www.acmicpc.net/problem/18870) | [📌](https://github.com/AlgoLeadMe/AlgoLeadMe-3/pull/117) |
+| 25차시 | 2024.03.05 | Perfix Sum | [21758 꿀 따기](https://www.acmicpc.net/problem/21758) | [🍯](https://github.com/AlgoLeadMe/AlgoLeadMe-3/pull/126) |


### PR DESCRIPTION
## 🔗 문제 링크
[백준 21758 : 꿀 따기](https://www.acmicpc.net/problem/21758)

## ✔️ 소요된 시간
70분

## ✨ 수도 코드
🎯 문제 이해
---
**알고리즘 유형 : 누적 합 (Prefix Sum)**

> **문제 요약**
> 각 칸마다 얻을 수 있는 꿀이 있다.
> 칸 중에서 서로 다른 2칸에 벌들 놓고, 또 다른 칸에는 벌통을 놓는다.
> 벌은 벌통이 있는 방향으로 가면서, 각 칸에 얻을 수 있는 꿀을 얻는다.
>
> 벌이 있는 칸은 꿀을 얻을 수 없고, 벌통이 있는 칸은 꿀을 얻을 수 있다.
>
> 예시
> <img src = "https://github.com/AlgoLeadMe/AlgoLeadMe-3/assets/113815454/b600bddc-1fd1-44d7-a2bd-6b94c377cef3" width = 300 >
> 위에 연한 회색에 벌이 있고, 진한 회색에 벌통이 있다고 했을 때,
> 각각의 벌은 ( 9 + 4 + 4 + 9 + 9 = 35 ) ( 4 + 9 + 9 = 22 )의 꿀을 벌통을 가지고 오는 걸 알 수 있다.

**유형 접근**
**누적 합 (Prefix Sum)** : 벌이 지나온 길을 다 더하는 문제이기 때문에 리스트의 구간합을 구하는 누적합을 사용하기 좋다

**문제 접근**
3가지 케이스에서 확인해야 하지만, 크게 보면 2가지 케이스로 나뉠 수 있다.
1. 벌통이 가운데 있을 때
2. 벌통이 맨 끝에 있을 때 ( 왼쪽 / 오른쪽 )

**벌통이 가운데 있는 경우**에는 벌은 양쪽 끝에 있어야 가장 많은 꿀을 얻을 수 있다.
> 벌통 왼쪽에 꿀이 많으면 그쪽에 벌을 2마리 둬야하는거 아닌가? 라는 생각이 들 수 있는데...
> 그 경우에는 2번 케이스로 넘어가서 벌통을 한 쪽 맨 끝으로 밀어내는 게 더 많은 꿀을 얻을 수 있다.
> 백준 예제 3번 같은 케이스가 이 경우에 해당된다.

**벌통이 맨 끝에 있는 경우**에는 반대편 제일 끝에는 무조건 벌이 있다. 벌과 벌통 사이의 값을 더할 때, 전체 다 합한 것이 꿀의 양이 많을 수 밖에 없다. 남은 벌 하나의 위치에 따라서 차이나는 값을 확인해야 한다.
> 왼쪽 오른쪽에 얼만큼 꿀의 양이 쏠려있는지에 따라 값이 달라질 수 있어서 양쪽 다 해주어야한다.

**각 케이스를 구하는 방법**
1. 중앙에 벌통
<img src ="https://github.com/AlgoLeadMe/AlgoLeadMe-3/assets/113815454/a6432c2d-4ed3-44fa-9089-a805e1561092" width = 500 >

위 그래프를 살펴보면
맨 끝에 두 인덱스에는 벌이 있고 벌통이 있는 위치만 한 번 더 더하기 때문에, 벌이 있는 위치를 제외하여 남은 칸의 꿀 중 가장 큰 값에 벌통이 위치하게 된다.

2. 맨끝에 벌통
<img src ="https://github.com/AlgoLeadMe/AlgoLeadMe-3/assets/113815454/e074b09e-a75d-4b07-b57b-008f6bdc2c68" width = 500 >

위 그래프의 내용을 사용하여, 가장 작은 값을 빼줄 수 있도록 값을 구했다.


🔍코드 설명
---
`place` : 총 칸의 수
`honey` : 각 칸의 꿀의 양을 기억하는 리스트
`total` : 주어진 총 꿀의 양
`honey_sum` : honey를 누적 합을 만든 값
`beehive` : 벌집. ( 각 케이스에서 구해진 꿀의 양 중에 최대값만 기억 )

주어진 입력 값을 받아주고, 꿀의 총 합은 각 케이스 계산에 계속 나오므로 미리 구해준다.
```py
place = int(input())
honey = list(map(int,input().split()))
total = sum(honey)
```

1. 중앙에 벌집이 있을 때
벌꿀의 총 합에서 벌의 위치를 빼주고, 꿀 중에서 max값을 더해준다.
벌의 위치는 맨 처음과 끝이므로 `honey[-1]`과 `honey[0]`을 빼주면 된다.
```py
beehive = total - honey[-1] - honey[0] + max(honey)
```

2. 오른쪽에 벌집이 있을 때
a. 우선 누적 합을 사용하여 각 index까지의 구간합이 어떻게 되는지 미리 구한다.
b. 각 index까지의 구간합과 해당 index의 꿀의 양, 맨 처음의 꿀의 양을 빼주고 그중에서 가장 작은 값을 반환해준다.
( 뒤에 2개는 벌의 위치 )
```py
def side_beehive():
    # a
    honey_sum = [i for i in honey]
    for p in range(1, place):
        honey_sum[p] += honey_sum[p-1]
    
    # b
    return (total*2 - min([honey[i]+honey_sum[i] for i in range(1,place-1)]) - honey[0])
```

3. 왼쪽에 벌집이 있을 때
그냥 honey를 `reverse()`함수를 이용하여 반대로 돌린 뒤에 위 함수를 다시 사용하면 된다.
```py
beehive = max(beehive, side_beehive()) # 오른쪽 벌통
honey.reverse()
beehive = max(beehive, side_beehive()) # 왼쪽 벌통
```

결국엔 가장 많이 꿀을 모은 경우만 `beehive`에 남아 있기 때문에 이를 출력해주면 된다.

<details>
<summary>전체 코드</summary>
<div markdown ="1">

```py
input = open(0).readline

place = int(input())
honey = list(map(int,input().split()))
total = sum(honey)

def side_beehive():
    honey_sum = [i for i in honey]

    for p in range(1, place):
        honey_sum[p] += honey_sum[p-1]
    
    return (total*2 - min([honey[i]+honey_sum[i] for i in range(1,place-1)]) - honey[0])

beehive = total - honey[-1] - honey[0] + max(honey)

beehive = max(beehive, side_beehive())
honey.reverse()
beehive = max(beehive, side_beehive())

print(beehive)
```

</div>
</details>

## 📚 새롭게 알게된 내용
없슴니당