### PR TITLE
36-xxubin04

### DIFF
--- a/xxubin04/Heap/1715_카드 정렬하기.py
+++ b/xxubin04/Heap/1715_카드 정렬하기.py
@@ -1,0 +1,14 @@
+from heapq import heapify, heappush, heappop
+input = open(0).readline 
+
+num = []
+total = 0
+heapify(num)
+for i in range(n := int(input())):
+    heappush(num, int(input()))
+
+while len(num) != 1:
+    total += (current_mix := heappop(num) + heappop(num))
+    heappush(num, current_mix)
+
+print(total) 


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
<!-- 해결한 문제의 링크를 올려주세요. -->
[백준 1715번 : 카드 정렬하기](https://www.acmicpc.net/problem/1715)

<br>

## ✔️ 소요된 시간
<!-- 문제를 해결하는데 소요된 시간을 적어주세요. -->

15분

<br>

## ✨ 수도 코드
<!-- 내가 작성한 코드를 모르는 사람이 봐도 이해할 수 있도록 글로 쉽게 풀어서 설명해주세요. -->
<!-- 알고리즘에 대한 지식이 전혀 없는 사람이 봐도 이해할 수 있도록 작성해주세요. 시각자료를 이용하면 더 좋습니다. -->
### 1. 문제 이해

카드가 10장, 20장, 40장 있다면, (10 + 20) + (30 + 40) = 100번의 비교로 카드를 정리하게 된다.

처음 10장과 20장을 비교할 때, 30번의 비교를 하게 된다.
그리고 30장과 40장의 카드를 비교할 때, 70번의 비교를 하게 된다.
-> 총 30번 + 70번 = **100번**의 비교

하지만, 10장과 40장을 먼저 비교하게 되면 50번의 비교를 하게 된다.
그리고 20장과 50장의 카드를 비교할 때, 70번의 비교를 하게 된다.
-> 총 50번 + 70번 = **120번**의 비교

그러므로, 총 30번 + 70번 = 100번의 비교가 최소의 비교 횟수이다.

<br>

위의 예시를 보면, 간단한 규칙을 알 수 있다.

> 카드의 장수가 작은 것들부터 비교를 해주게 되면 비교횟수가 최소가 된다.

왜냐하면 10장, 20장, 40장의 카드가 있을 때, (10 + 20) + (30 + 40) = 100이다.
이때, 30은 10 + 20이므로 맨 처음 비교해서 합친 카드들은 40장의 카드와 합칠 때, 다시 한번 비교하게 된다. 그러므로, 적은 장수의 카드들을 여러 번 비교할 수록 최소한의 비교횟수를 가질 수 있다.

<br>

### 2. 코드분석

```python
from heapq import heapify, heappush, heappop
input = open(0).readline 

num = []
total = 0
heapify(num)
for i in range(n := int(input())):
    heappush(num, int(input()))

while len(num) != 1:
    total += (current_mix := heappop(num) + heappop(num))
    heappush(num, current_mix)

print(total) 
```

heapq 모듈을 통해 heap을 구현하여 문제를 간단하게 풀 수 있다.
우리는 작은 숫자들부터 계산해주어야 하므로 최소 힙을 사용하면 된다.

heapify을 사용하여 `num`을 힙으로 변환해준다.
`num`에 입력받은 카드의 장수를 heappush해준다.

`num`에 들어있는 원소의 개수가 1이 되기 전까지 비교횟수를 저장하는 `total`에 가장 작은 수와 두번째로 작은 수를 더한 값을 더해준다. 그리고 그 값을 heappush해주고 다시 위의 과정을 반복한다.

`num`에 하나의 숫자만 들어있는 경우는 모든 카드들이 합쳐져 더이상 비교해줄 필요가 없는 경우이다. 그러므로, 비교횟수인 `total`을 출력해준다.

<br>

## 📚 새롭게 알게된 내용
<!-- 새롭게 알게된 내용이 있다면 작성 해주시고 출처를 남겨주세요. -->
교황선배님의 추천으로 풀어봤는데 좋은 문제였습니다!!😊
문제 추천해주셔서 감사해요!👍
